### PR TITLE
Fix deprecation warnings

### DIFF
--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -18,9 +18,6 @@ copyright = "Copyright &copy; {year}"
 # Enable analytics by entering your Google Analytics tracking ID
 googleAnalytics = "UA-123456-78" # example: UA-123456-78, for more info, read the article https://support.google.com/analytics/answer/1008080?hl=en
 
-# Enable comments by entering your Disqus shortname
-disqusShortname = "themefisher-template" # we use disqus to show comments in blog posts . To install disqus please follow this tutorial https://portfolio.peter-baumgartner.net/2017/09/10/how-to-install-disqus-on-hugo/
-
 ############################
 ## Advanced options below ##
 ############################
@@ -41,6 +38,11 @@ paginate = 10  # Number of items per page in paginated lists.
 enableEmoji = true
 footnotereturnlinkcontents = "<sup>^</sup>"
 ignoreFiles = ["\\.ipynb$", ".ipynb_checkpoints$", "\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
+
+[services]
+# Enable comments by entering your Disqus shortname
+[services.disqus]
+Shortname = "themefisher-template" # we use disqus to show comments in blog posts . To install disqus please follow this tutorial https://portfolio.peter-baumgartner.net/2017/09/10/how-to-install-disqus-on-hugo/
 
 # Build
 [build]

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -20,10 +20,10 @@ description = ""
 # Default image for social sharing and search engines. Place image in `static/img/` folder and specify image name here.
 sharing_image = ""
 
-# Twitter username (without @). Used when a vistor shares your site on Twitter.
+# Twitter username (without @). Used when a visitor shares your site on Twitter.
 twitter = ""
 
-# Diplay a logo in navigation bar rather than title (optional).
+# Display a logo in navigation bar rather than title (optional).
 #   To enable, place an image in `static/img/` and reference its filename below. To disable, set the value to "".
 logo = ""
 

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,4 +1,4 @@
-{{ if and site.DisqusShortname (not (or site.Params.disable_comments .Params.disable_comments)) }}
+{{ if and .Site.Config.Services.Disqus.Shortname (not (or site.Params.disable_comments .Params.disable_comments)) }}
 <section id="comments">
   {{ template "_internal/disqus.html" . }}
 </section>

--- a/layouts/partials/page_metadata.html
+++ b/layouts/partials/page_metadata.html
@@ -49,7 +49,7 @@
   </span>
   {{ end }}
 
-  {{ $comments_enabled := and site.DisqusShortname (not (or site.Params.disable_comments (eq $page.Params.comments false))) }}
+  {{ $comments_enabled := and .Site.Config.Services.Disqus.Shortname (not (or site.Params.disable_comments (eq $page.Params.comments false))) }}
   {{ if and $comments_enabled (site.Params.comment_count | default true) }}
   <span class="middot-divider"></span>
   <a href="{{ $page.RelPermalink }}#disqus_thread"><!-- Count will be inserted here --></a>

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -117,7 +117,7 @@
     <link rel="stylesheet" href="{{ $css_bundle.RelPermalink }}">
   {{ end }}
 
-  {{ if not site.IsServer }}
+  {{ if not hugo.IsServer }}
   {{ if site.Params.microsoft_clarity }}
     <script type="text/javascript">
       (function(c,l,a,r,i,t,y){

--- a/layouts/partials/site_js.html
+++ b/layouts/partials/site_js.html
@@ -45,9 +45,9 @@
     {{ end }}
 
     {{/* Comments JS. */}}
-    {{ $comments_enabled := and site.DisqusShortname (not (or site.Params.disable_comments $.Params.disable_comments)) }}
+    {{ $comments_enabled := and .Site.Config.Services.Disqus.Shortname (not (or site.Params.disable_comments $.Params.disable_comments)) }}
     {{ if and $comments_enabled (site.Params.comment_count | default true) }}
-    <script id="dsq-count-scr" src="//{{ site.DisqusShortname }}.disqus.com/count.js" async></script>
+    <script id="dsq-count-scr" src="//{{ .Site.Config.Services.Disqus.Shortname }}.disqus.com/count.js" async></script>
     {{ end }}
 
     {{/* Initialise code highlighting. */}}


### PR DESCRIPTION
When serving example site with latest hugo version 0.127.0, deprecation warnings are shown.

```
WARN  deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0
and will be removed in a future release.
Use .Site.Config.Services.Disqus.Shortname instead.
```

```
WARN  deprecated: .Site.IsServer was deprecated in Hugo v0.120.0
and will be removed in a future release. Use hugo.IsServer instead.
```

This PR fixes these issues.
This PR resolves #37.