### PR TITLE
Support hugo >= v0.134.0

### DIFF
--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -127,10 +127,10 @@
       })(window, document, "clarity", "script", "{{ site.Params.microsoft_clarity }}");
     </script>
   {{ end }}
-  {{ if site.GoogleAnalytics }}
+  {{ if site.Config.Services.GoogleAnalytics.ID }}
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-      ga('create', '{{ site.GoogleAnalytics }}', 'auto');
+      ga('create', '{{ site.Config.Services.GoogleAnalytics.ID }}', 'auto');
       {{ if site.Params.privacy_pack }}ga('set', 'anonymizeIp', true);{{ end }}
       ga('require', 'eventTracker');
       ga('require', 'outboundLinkTracker');


### PR DESCRIPTION
According to https://discourse.gohugo.io/t/site-googleanalytics-was-deprecated-in-hugo-v0-120-0-and-will-be-removed-in-hugo-0-134-0/51395, `.Site.GoogleAnalytics` is unsupported since that version. I can confirm that this results in errors for me on v0.139.2 and this commit fixes it for me.