### PR TITLE
Upgrade Font Awesome to v6.7.1

### DIFF
--- a/data/assets.toml
+++ b/data/assets.toml
@@ -67,8 +67,8 @@
 # CSS
 
 [css.fontAwesome]
-  version = "5.6.0"
-  sri = "sha384-aOkxzJ5uQz7WBObEZcHvV5JvRW3TUc2rNPA7pe3AwnsUohiw1Vj2Rgx2KSOkF5+h"
+  version = "6.7.1"
+  sri = "sha512-y0n544EuLCYq83Tnm9iQXLUIpFvywtavYu7YWvQ3cIckhqVelCWIL+2p+zpXoxejwYvh4oatrwx2vn8bDfqEdA==%"
   url = "https://use.fontawesome.com/releases/v%s/css/all.css"
 [css.academicons]
   version = "1.8.6"


### PR DESCRIPTION
Font Awesome v5.x is in LTS mode and does only receive critical security fixes at this point.
The current Version 6.x is backwards-compatible and offers a lot of new icons that are missing from v5.x.
This PR upgrades Font Awesome to the currently latest version.